### PR TITLE
Compatibility fix for php5.3

### DIFF
--- a/src/nlac/NLSClientScript.php
+++ b/src/nlac/NLSClientScript.php
@@ -443,9 +443,10 @@ class NLSClientScript extends \CClientScript {
 		$this->mergeIfXhr = ($this->mergeIfXhr ? 1 : 0);
 
 		//js code
+		$that = $this;
 		$js = file_get_contents(__DIR__ . '/nlsc.min.js');
-		$js = preg_replace_callback('/_(excludePattern|includePattern|mergeIfXhr|resMap2Request)_/', function($m) {
-			return trim($this->$m[1],';');
+		$js = preg_replace_callback('/_(excludePattern|includePattern|mergeIfXhr|resMap2Request)_/', function ($m) use ($that) {
+			return trim($that->$m[1],';');
 		}, $js);
 
 		$this->registerScript('fixDuplicateResources', $js, \CClientScript::POS_HEAD);


### PR DESCRIPTION
In PHP 5.3 you cannot refer to $this from the lambda functions (NLSClientScript:449).
To fix this you should define variable, e.g. `$that` and pass it to the lambda function with `use`.
